### PR TITLE
intermediate models updated with new cols, forms_mapping models added

### DIFF
--- a/models/intermediate/int_barula_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_barula_community_2025_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_baseline_questionnaire_bareilly.sql
+++ b/models/intermediate/int_baseline_questionnaire_bareilly.sql
@@ -31,6 +31,11 @@ with transformed as (
 {% set rel = ref('stg_baseline_questionnaire_bareilly') %}
 
 {% set colname_per = get_column_by_substring_postgres(rel, 'firstperiodage') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 {% set colname_age = get_column_by_substring_postgres(rel, 'E_Age_of_respondent') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, '_4_Which_product_do_you_most_o') %}
 {% set colname_menst_disp = get_column_by_substring_postgres(rel, '_19_Where_do_you_dispose_of_yo') %}
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_bir_community_baseline2025.sql
+++ b/models/intermediate/int_bir_community_baseline2025.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_caf_ajmer_2024_baselineendline_survey.sql
+++ b/models/intermediate/int_caf_ajmer_2024_baselineendline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_caf_ajmer_students_2025_baseline_survey.sql
+++ b/models/intermediate/int_caf_ajmer_students_2025_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed t

--- a/models/intermediate/int_caf_delhi_school_2024_baseline_survey.sql
+++ b/models/intermediate/int_caf_delhi_school_2024_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_caf_delhi_school_2025_endline_survey.sql
+++ b/models/intermediate/int_caf_delhi_school_2025_endline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_elephanta_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_elephanta_community_2025_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_elephanta_community_2025_endline_survey.sql
+++ b/models/intermediate/int_elephanta_community_2025_endline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_fbc_community_2024_baseline_survey.sql
+++ b/models/intermediate/int_fbc_community_2024_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_fbc_school_boys_2024_baseline_survey.sql
+++ b/models/intermediate/int_fbc_school_boys_2024_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_fbc_school_boys_2024_endline_survey.sql
+++ b/models/intermediate/int_fbc_school_boys_2024_endline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_fbc_school_girls_2024_baseline_survey.sql
+++ b/models/intermediate/int_fbc_school_girls_2024_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_fbc_school_girls_2024_endline_survey.sql
+++ b/models/intermediate/int_fbc_school_girls_2024_endline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_fbc_women_jhatingri_baseline_questionaire.sql
+++ b/models/intermediate/int_fbc_women_jhatingri_baseline_questionaire.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_ffec_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_ffec_community_2025_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
-
+    
 from transformed

--- a/models/intermediate/int_jakson_cc_trainers_2025_survey.sql
+++ b/models/intermediate/int_jakson_cc_trainers_2025_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Trainer_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_jakson_community_2024_baseline_survey.sql
+++ b/models/intermediate/int_jakson_community_2024_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_jakson_community_2025_endline_survey.sql
+++ b/models/intermediate/int_jakson_community_2025_endline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_jk_fenner_hyd_2025_baseline_survey.sql
+++ b/models/intermediate/int_jk_fenner_hyd_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_jk_fenner_hyd_2025_phase_2_baseline_survey.sql
+++ b/models/intermediate/int_jk_fenner_hyd_2025_phase_2_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_ods_to_ease_the_pain') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_kokari_2024_baseline_survey.sql
+++ b/models/intermediate/int_kokari_2024_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_kokari_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_kokari_community_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_kokari_community_2025_endline_survey.sql
+++ b/models/intermediate/int_kokari_community_2025_endline_survey.sql
@@ -52,6 +52,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -159,6 +164,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_majuli_needs_assessment.sql
+++ b/models/intermediate/int_majuli_needs_assessment.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mamta_2025_endline_survey.sql
+++ b/models/intermediate/int_mamta_2025_endline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mamta_school_2023_workshop_long_survey.sql
+++ b/models/intermediate/int_mamta_school_2023_workshop_long_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mamta_school_2023_workshop_short_survey_ece.sql
+++ b/models/intermediate/int_mamta_school_2023_workshop_short_survey_ece.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mamta_school_2024_baseline_survey.sql
+++ b/models/intermediate/int_mamta_school_2024_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mamta_school_2025_endline_survey.sql
+++ b/models/intermediate/int_mamta_school_2025_endline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mosonie_dc_project_teachers_2025_baseline_survey.sql
+++ b/models/intermediate/int_mosonie_dc_project_teachers_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mosonie_dc_student_2025_baseline_survey.sql
+++ b/models/intermediate/int_mosonie_dc_student_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_mosonie_irctc_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_mosonie_irctc_community_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_msi_cs_2024_baseline_survey.sql
+++ b/models/intermediate/int_msi_cs_2024_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_msi_cs_2024_endline_survey.sql
+++ b/models/intermediate/int_msi_cs_2024_endline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_msi_cs_2025_baseline_survey.sql
+++ b/models/intermediate/int_msi_cs_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_msi_cs_2025_endline_survey.sql
+++ b/models/intermediate/int_msi_cs_2025_endline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_msi_trainers_2025_baseline_survey.sql
+++ b/models/intermediate/int_msi_trainers_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_ntpc_community_2024_baseline_survey.sql
+++ b/models/intermediate/int_ntpc_community_2024_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_ratio') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_marit') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'Ask_the_respondent_What_reme') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_ntpc_community_2025_endline_survey.sql
+++ b/models/intermediate/int_ntpc_community_2025_endline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_ratio') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_marit') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'Ask_the_respondent_What_reme') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_observation_checklist.sql
+++ b/models/intermediate/int_observation_checklist.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_rajkot_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_rajkot_community_2025_baseline_survey.sql
@@ -51,6 +51,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -158,6 +163,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
     
 from transformed

--- a/models/intermediate/int_tfi_school_2024_baseline_survey.sql
+++ b/models/intermediate/int_tfi_school_2024_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_tfi_school_2024_endline_survey.sql
+++ b/models/intermediate/int_tfi_school_2024_endline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/intermediate/int_yflo_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_yflo_community_2025_baseline_survey.sql
@@ -50,6 +50,11 @@ with transformed as (
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
+{% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
+{% set colname_block = get_column_by_substring_postgres(rel, 'block') %}
+{% set colname_village = get_column_by_substring_postgres(rel, 'village') %}
+{% set colname_unit_type = get_column_by_substring_postgres(rel, 'unit') %}
 
 select 
     -- Apply any final transformations or column selections
@@ -157,6 +162,31 @@ select
         {{ colname_menst_rem }} as menstrual_remedies
     {% else %}
         'N/A' as menstrual_remedies
+    {% endif %},
+    {% if colname_state != 'N/A' %}
+        {{ colname_state }} as state_name
+    {% else %}
+        'N/A' as state_name
+    {% endif %},
+    {% if colname_district != 'N/A' %}
+        {{ colname_district }} as district_name
+    {% else %}
+        'N/A' as district_name
+    {% endif %},
+    {% if colname_block != 'N/A' %}
+        {{ colname_block }} as block_name
+    {% else %}
+        'N/A' as block_name
+    {% endif %},
+    {% if colname_village != 'N/A' %}
+        {{ colname_village }} as village_name
+    {% else %}
+        'N/A' as village_name
+    {% endif %},
+    {% if colname_unit_type != 'N/A' %}
+        {{ colname_unit_type }} as unit_type
+    {% else %}
+        'N/A' as unit_type
     {% endif %}
 
 from transformed

--- a/models/marts/forms_mapping.sql
+++ b/models/marts/forms_mapping.sql
@@ -1,0 +1,89 @@
+{{
+    config(
+        materialized='table',
+        tags=['mart', 'combined']
+    )
+}}
+
+-- mart model to apply forms_mapping logic to all_forms_combined table
+-- business logic to only preserve forms of interest and append extra columns for metrics calculation
+
+with source as (
+    select *, 
+        case when age <> 'N/A' and age ~ '^[0-9]+$' then cast(age as integer) else null end as age_int
+    from {{ ref('all_forms_combined') }}
+),
+
+forms_mapping as (
+    select *
+    from {{ ref('stg_forms_mapping') }}
+),
+
+forms_mapped as (
+    SELECT
+        s.form_name,
+        s.firstperiodage,
+        s.age,
+        s.age_int,
+        case 
+            when s.age_int is null then 'N/A'
+            when s.age_int >= 7 and s.age_int <= 9 then '7-9 years'
+            when s.age_int >= 10 and s.age_int <= 14 then '10-14 years'
+            when s.age_int >= 15 and s.age_int <= 24 then '15-24 years'
+            when s.age_int >= 25 and s.age_int <= 34 then '25-34 years'
+            when s.age_int >= 35 and s.age_int <= 44 then '35-44 years'
+            when s.age_int >= 45 and s.age_int <= 54 then '45-54 years'
+            when s.age_int >= 55 then '55 and above'
+        end as age_group,
+        s.menstrual_material,
+        s.menstrual_disposal,
+        s.menstrual_pms,
+        s.menstrual_symptoms,
+        s.menstrual_tradition,
+        s.menstrual_spend,
+        s.menstrual_prediction,
+        s.menstrual_info,
+        s.menstrual_setback,
+        s.smartphone_access,
+        s.firstperiodknowledge,
+        s.menstrual_anxiety,
+        s.religion,
+        s.caste,
+        s.occupation,
+        s.education,
+        s.ration_card,
+        s.marital_status,
+        s.menstrual_remedies,
+        CASE
+            when f.state_name is not null then f.state_name
+            else s.state_name
+        END as state_name,
+        CASE
+            when f.district_name is not null then f.district_name
+            else s.district_name
+        END as district_name,
+        CASE
+            when f.block_name is not null then f.block_name
+            else s.block_name
+        END as block_name,
+        f.sub_district_name,
+        CASE
+            when f.town_village_name is not null then f.town_village_name
+            else s.village_name
+        END as town_village_name,
+        CASE
+            when f.unit_type is not null then f.unit_type
+            else s.unit_type
+        END as unit_type,
+        f.beneficiary_type,
+        f.place,
+        f.place_type,
+        f.enrollment_type
+
+    from source s inner join forms_mapping f
+    on s.form_name = f.form_name
+)
+
+select *
+from forms_mapped
+where form_name is not null

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -185,3 +185,11 @@ sources:
       - name: elephanta_community_2025_endline_survey
         identifier: "Elephanta_Community_2025_endline_survey"
         description: "Elephanta Community 2025 endline survey data"
+
+  - name: forms_mapping_data
+    description: "Forms mapping sheet containing list of relevant forms to be analysed & extra fields to be appended"
+    schema: "kobotoolbox_source_data"
+    tables:
+      - name: forms_mapping_sheet
+        identifier: "Forms_Mapping"
+        description: "Forms mapping sheet data"

--- a/models/staging/stg_forms_mapping.sql
+++ b/models/staging/stg_forms_mapping.sql
@@ -1,0 +1,47 @@
+{{
+    config(
+        materialized='table',
+        tags=['staging', 'combined']
+    )
+}}
+
+-- statging model to clean forms_mapping data
+
+with source as (
+    select 
+        nullif(btrim(forms), '') as form_name,
+        nullif(btrim(state), '') as state_name,
+        nullif(btrim(district), '') as district_name,
+        nullif(btrim(sub_district), '') as sub_district_name,
+        nullif(btrim(block), '') as block_name,
+        nullif(btrim(town_village), '') as town_village_name,
+        nullif(btrim(unit_type), '') as unit_type,
+        nullif(btrim(beneficiary_type), '') as beneficiary_type,
+        nullif(btrim(place), '') as place,
+        nullif(btrim(if_school_then_school_type), '') as school_type,
+        nullif(btrim(if_school_then_enrollment_type), '') as enrollment_type,
+        nullif(btrim(if_community_then_community_type), '') as community_type
+    from {{ source('forms_mapping_data', 'forms_mapping_sheet') }}
+),
+
+cleaned as (
+    SELECT  
+        form_name,
+        state_name,
+        district_name,
+        sub_district_name,
+        block_name,
+        town_village_name,
+        unit_type,
+        beneficiary_type,
+        place,
+        case when place = 'School' then school_type else community_type end as place_type,
+        case when place = 'School' then enrollment_type else 'N/A' end as enrollment_type
+
+    from source
+)
+
+SELECT *
+FROM cleaned
+WHERE form_name IS NOT NULL
+AND form_name != 'NA'


### PR DESCRIPTION
## Summary

to enable filtering of metric data based on geography, intermediate models updated with new cols corresponding to state, district, block, village, unit. Additionally, forms_mapping sheet was provided, which contains list of forms relevant and list of external columns to be mapped to those forms.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [y] Ran `dbt test` before pushing this PR?
- [y] If you've fixed a bug or added code, the code has been tested and has test cases.
- [y] Is CI/CD passing?

## Notes

sources.yml: 
>forms_mapping table sources added

staging:
>_stg_forms_mapping:_ raw forms_mapping table is extracted from source, cleaned and put in stg layer for futher use.

all intermediate models: f
>or every int model, 5 new columns corresponding to state, district, block, village, unit extracted from stg layer and added to output select statement.

marts:
>_forms_mapping:_ to the all_forms_combined table, the forms_mapping table is joined to only keep relevant forms mentioned in the forms_mapping sheet. all extracted columns are put and external columns given in forms_mapping sheet is joined to the forms. for state, district, block, village, unit logic is to check if data exists for these fields in the corresponding form, if not then corresponding cols are extracted from foms_mapping table & these are then put in the final select statement, otherwise the forms fields are put.