### PR TITLE
linting fixed for stg & int models + form variable names updated in relevant int models

### DIFF
--- a/.github/workflows/.dbt-ci.yml
+++ b/.github/workflows/.dbt-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.13.7'
 
       #REMOVE Step 3,4,5 if your project doesn't need an SSH Tunnel
       # Step 3: Add SSH private key and configure known_hosts

--- a/.github/workflows/.dbt-ci.yml
+++ b/.github/workflows/.dbt-ci.yml
@@ -61,7 +61,7 @@ jobs:
           mkdir -p /home/runner/.dbt
           echo "Creating profiles.yml..."
           cat <<EOF > /home/runner/.dbt/profiles.yml
-          <dbt_project_name>:
+          dbt_project_baala:
             outputs:
               dev:
                 dbname: "{{ env_var('POSTGRES_DBNAME') }}"

--- a/models/intermediate/int_barula_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_barula_community_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_barula_community_2025_baseline_survey'), 

--- a/models/intermediate/int_baseline_questionnaire_bareilly.sql
+++ b/models/intermediate/int_baseline_questionnaire_bareilly.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_baseline_questionnaire_bareilly'), 

--- a/models/intermediate/int_bir_community_baseline2025.sql
+++ b/models/intermediate/int_bir_community_baseline2025.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_bir_community_baseline2025'), 

--- a/models/intermediate/int_caf_ajmer_2024_baselineendline_survey.sql
+++ b/models/intermediate/int_caf_ajmer_2024_baselineendline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_caf_ajmer_2024_baselineendline_survey'), 

--- a/models/intermediate/int_caf_ajmer_students_2025_baseline_survey.sql
+++ b/models/intermediate/int_caf_ajmer_students_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_caf_ajmer_students_2025_baseline_survey'), 
@@ -190,4 +190,4 @@ select
         'N/A' as unit_type
     {% endif %}
     
-from transformed t
+from transformed

--- a/models/intermediate/int_caf_delhi_school_2024_baseline_survey.sql
+++ b/models/intermediate/int_caf_delhi_school_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_caf_delhi_school_2024_baseline_survey'), 

--- a/models/intermediate/int_caf_delhi_school_2025_endline_survey.sql
+++ b/models/intermediate/int_caf_delhi_school_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_caf_delhi_school_2025_endline_survey'), 

--- a/models/intermediate/int_elephanta_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_elephanta_community_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_elephanta_community_2025_baseline_survey'), 

--- a/models/intermediate/int_elephanta_community_2025_endline_survey.sql
+++ b/models/intermediate/int_elephanta_community_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_elephanta_community_2025_endline_survey'), 

--- a/models/intermediate/int_fbc_community_2024_baseline_survey.sql
+++ b/models/intermediate/int_fbc_community_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_fbc_community_2024_baseline_survey'), 

--- a/models/intermediate/int_fbc_school_boys_2024_baseline_survey.sql
+++ b/models/intermediate/int_fbc_school_boys_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_fbc_school_boys_2024_baseline_survey'), 

--- a/models/intermediate/int_fbc_school_boys_2024_endline_survey.sql
+++ b/models/intermediate/int_fbc_school_boys_2024_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_fbc_school_boys_2024_endline_survey'), 

--- a/models/intermediate/int_fbc_school_girls_2024_baseline_survey.sql
+++ b/models/intermediate/int_fbc_school_girls_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_fbc_school_girls_2024_baseline_survey'), 

--- a/models/intermediate/int_fbc_school_girls_2024_endline_survey.sql
+++ b/models/intermediate/int_fbc_school_girls_2024_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_fbc_school_girls_2024_endline_survey'), 

--- a/models/intermediate/int_fbc_women_jhatingri_baseline_questionaire.sql
+++ b/models/intermediate/int_fbc_women_jhatingri_baseline_questionaire.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_fbc_women_jhatingri_baseline_questionaire'), 

--- a/models/intermediate/int_ffec_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_ffec_community_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_ffec_community_2025_baseline_survey'), 
@@ -43,11 +43,11 @@ with transformed as (
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, 'woman_act') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
-{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'How_often_do_you_feel_anxious_') %}
+{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'How_often_do_you_fee_t_on_your_daily_life') %}
 {% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_woman_s_religion') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
-{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_educa') %}
+{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_responde_t_s_education_status') %}
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}

--- a/models/intermediate/int_jakson_cc_trainers_2025_survey.sql
+++ b/models/intermediate/int_jakson_cc_trainers_2025_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_jakson_cc_trainers_2025_survey'), 

--- a/models/intermediate/int_jakson_community_2024_baseline_survey.sql
+++ b/models/intermediate/int_jakson_community_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_jakson_community_2024_baseline_survey'), 

--- a/models/intermediate/int_jakson_community_2025_endline_survey.sql
+++ b/models/intermediate/int_jakson_community_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_jakson_community_2025_endline_survey'), 

--- a/models/intermediate/int_jk_fenner_hyd_2025_baseline_survey.sql
+++ b/models/intermediate/int_jk_fenner_hyd_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_jk_fenner_hyd_2025_baseline_survey'), 
@@ -36,8 +36,8 @@ with transformed as (
 {% set colname_pms = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'Ask_the_respondent_On_averag') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Ask_the_respondent_Can_you_u') %}
+{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'Ask_the_respondent_g_a_sanitary_product') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Ask_the_respondent_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, 'woman_act') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
@@ -46,9 +46,9 @@ with transformed as (
 {% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_relig') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
-{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_educa') %}
+{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_responde_t_s_education_status') %}
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
-{% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
+{% set colname_marit_status = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
 {% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
 {% set colname_district = get_column_by_substring_postgres(rel, 'district') %}

--- a/models/intermediate/int_jk_fenner_hyd_2025_phase_2_baseline_survey.sql
+++ b/models/intermediate/int_jk_fenner_hyd_2025_phase_2_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_jk_fenner_hyd_2025_phase_2_baseline_survey'), 
@@ -40,10 +40,10 @@ with transformed as (
 {% set colname_menst_spend = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'Have_you_in_the_past_three_mon') %}
+{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'Have_you_in_the_past_due_to_your_period') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
-{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'how_often_do_you_fee_t_on_your_daily_life') %}
 {% set colname_religion = get_column_by_substring_postgres(rel, 'Religion') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, '-') %}

--- a/models/intermediate/int_kokari_2024_baseline_survey.sql
+++ b/models/intermediate/int_kokari_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_kokari_2024_baseline_survey'), 

--- a/models/intermediate/int_kokari_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_kokari_community_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_kokari_community_2025_baseline_survey'), 
@@ -35,21 +35,21 @@ with transformed as (
 {% set colname_menst_disp = get_column_by_substring_postgres(rel, 'woman_dispose') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, 'woman_pms') %}
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
-{% set colname_periodtrad = get_column_by_substring_postgres(rel, 'Ask_the_woman_What_are_some_') %}
-{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_money_do_') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_predict_when_m') %}
+{% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
+{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_g_a_sanitary_product') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'woman_act') %}
+{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'how_often_do_you_fee_t_on_your_daily_life') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
 {% set colname_menst_anxiety = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_relig') %}
+{% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_woman_s_religion') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
 {% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_educa') %}
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
-{% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
 {% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
 {% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
 {% set colname_block = get_column_by_substring_postgres(rel, 'block') %}

--- a/models/intermediate/int_kokari_community_2025_endline_survey.sql
+++ b/models/intermediate/int_kokari_community_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_kokari_community_2025_endline_survey'), 

--- a/models/intermediate/int_majuli_needs_assessment.sql
+++ b/models/intermediate/int_majuli_needs_assessment.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_majuli_needs_assessment'), 

--- a/models/intermediate/int_mamta_2025_endline_survey.sql
+++ b/models/intermediate/int_mamta_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mamta_2025_endline_survey'), 

--- a/models/intermediate/int_mamta_school_2023_workshop_long_survey.sql
+++ b/models/intermediate/int_mamta_school_2023_workshop_long_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mamta_school_2023_workshop_long_survey'), 

--- a/models/intermediate/int_mamta_school_2023_workshop_short_survey_ece.sql
+++ b/models/intermediate/int_mamta_school_2023_workshop_short_survey_ece.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mamta_school_2023_workshop_short_survey_ece'), 

--- a/models/intermediate/int_mamta_school_2024_baseline_survey.sql
+++ b/models/intermediate/int_mamta_school_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mamta_school_2024_baseline_survey'), 

--- a/models/intermediate/int_mamta_school_2025_endline_survey.sql
+++ b/models/intermediate/int_mamta_school_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mamta_school_2025_endline_survey'), 

--- a/models/intermediate/int_mosonie_dc_project_teachers_2025_baseline_survey.sql
+++ b/models/intermediate/int_mosonie_dc_project_teachers_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mosonie_dc_project_teachers_2025_baseline_survey'), 
@@ -37,7 +37,7 @@ with transformed as (
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
 {% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_money_do_') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_predict_when_m') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, 'periodscmiss') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}

--- a/models/intermediate/int_mosonie_dc_student_2025_baseline_survey.sql
+++ b/models/intermediate/int_mosonie_dc_student_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mosonie_dc_student_2025_baseline_survey'), 
@@ -37,9 +37,9 @@ with transformed as (
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
 {% set colname_menst_spend = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_predict_when_m') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'Have_you_in_the_past_three_mon') %}
+{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'Have_you_in_the_past_due_to_your_period') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
 {% set colname_menst_anxiety = get_column_by_substring_postgres(rel, '-') %}
@@ -49,7 +49,7 @@ with transformed as (
 {% set colname_edu = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_ods_to_ease_the_pain') %}
 {% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
 {% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
 {% set colname_block = get_column_by_substring_postgres(rel, 'block') %}

--- a/models/intermediate/int_mosonie_irctc_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_mosonie_irctc_community_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_mosonie_irctc_community_2025_baseline_survey'), 
@@ -36,10 +36,10 @@ with transformed as (
 {% set colname_pms = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
-{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_money_do_') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_predict_when_m') %}
+{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_g_a_sanitary_product') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_setback = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'how_often_do_you_fee_t_on_your_daily_life') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_anxiety = get_column_by_substring_postgres(rel, '-') %}

--- a/models/intermediate/int_msi_cs_2024_baseline_survey.sql
+++ b/models/intermediate/int_msi_cs_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_msi_cs_2024_baseline_survey'), 

--- a/models/intermediate/int_msi_cs_2024_endline_survey.sql
+++ b/models/intermediate/int_msi_cs_2024_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_msi_cs_2024_endline_survey'), 

--- a/models/intermediate/int_msi_cs_2025_baseline_survey.sql
+++ b/models/intermediate/int_msi_cs_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_msi_cs_2025_baseline_survey'), 
@@ -31,25 +31,25 @@ with transformed as (
 
 {% set colname_per = get_column_by_substring_postgres(rel, 'woman_ageperiod') %}
 {% set colname_age = get_column_by_substring_postgres(rel, 'Age_of_the_respondent') %}
-{% set colname_menst_mat = get_column_by_substring_postgres(rel, 'Which_of_the_following_product') %}
-{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'How_do_you_dispose_the_product') %}
-{% set colname_pms = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_symp = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_periodtrad = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_money_do_') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_menst_mat = get_column_by_substring_postgres(rel, 'Ask_the_respondent_What_is_t') %}
+{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'woman_dispose') %}
+{% set colname_pms = get_column_by_substring_postgres(rel, 'woman_pms') %}
+{% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
+{% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
+{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_g_a_sanitary_product') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_setback = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_menst_setback = get_column_by_substring_postgres(rel, 'woman_act') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_firstperiod = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_religion = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_caste = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_occupation = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_edu = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
+{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'how_often_do_you_fee_t_on_your_daily_life') %}
+{% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_woman_s_religion') %}
+{% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
+{% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
+{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_responde_t_s_education_status') %}
+{% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
+{% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
+{% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}
 {% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
 {% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
 {% set colname_block = get_column_by_substring_postgres(rel, 'block') %}

--- a/models/intermediate/int_msi_cs_2025_endline_survey.sql
+++ b/models/intermediate/int_msi_cs_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_msi_cs_2025_endline_survey'), 
@@ -32,21 +32,21 @@ with transformed as (
 {% set colname_per = get_column_by_substring_postgres(rel, 'woman_ageperiod') %}
 {% set colname_age = get_column_by_substring_postgres(rel, 'woman_age') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, 'What_is_the_main_absorbent_mat') %}
-{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_How_do_yo') %}
+{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_ispose_the_materials') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, 'woman_pms') %}
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, 'periodtrad') %}
-{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_money_do_') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_predict_when_m') %}
+{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_g_a_sanitary_product') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, 'periodscmiss') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, 'Do_you_have_access_to_a_smartp') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
-{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'How_often_do_you_feel_anxious_') %}
+{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'how_often_do_you_fee_t_on_your_daily_life') %}
 {% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_woman_s_religion') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
-{% set colname_edu = get_column_by_substring_postgres(rel, 'resp_edu') %}
+{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_responde_t_s_education_status') %}
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'period_pain_rem') %}

--- a/models/intermediate/int_msi_trainers_2025_baseline_survey.sql
+++ b/models/intermediate/int_msi_trainers_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_msi_trainers_2025_baseline_survey'), 

--- a/models/intermediate/int_ntpc_community_2024_baseline_survey.sql
+++ b/models/intermediate/int_ntpc_community_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_ntpc_community_2024_baseline_survey'), 
@@ -30,25 +30,25 @@ with transformed as (
 {% set rel = ref('stg_ntpc_community_2024_baseline_survey') %}
 
 {% set colname_per = get_column_by_substring_postgres(rel, 'first_menstrual_period') %}
-{% set colname_age = get_column_by_substring_postgres(rel, 'woman_age') %}
+{% set colname_age = get_column_by_substring_postgres(rel, 'Age_of_the_respondent') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, 'mixed_material') %}
-{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_How_do_yo') %}
+{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_ispose_the_materials') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
+{% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_y_you_or_your_family') %}
 {% set colname_menst_spend = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Ask_the_respondent_Can_you_u') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Ask_the_respondent_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_firstperiod = get_column_by_substring_postgres(rel, 'Ask_the_respondent_Before_yo') %}
+{% set colname_firstperiod = get_column_by_substring_postgres(rel, 'Ask_the_respondent_w_about_menstruation') %}
 {% set colname_menst_anxiety = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_relig') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
-{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_educa') %}
-{% set colname_ration = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_ratio') %}
-{% set colname_marit_status = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_marit') %}
+{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_responde_ion_education_status') %}
+{% set colname_ration = get_column_by_substring_postgres(rel, 'What_is_the_responde_s_ration_card_status') %}
+{% set colname_marit_status = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'Ask_the_respondent_What_reme') %}
 {% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
 {% set colname_district = get_column_by_substring_postgres(rel, 'district') %}

--- a/models/intermediate/int_ntpc_community_2025_endline_survey.sql
+++ b/models/intermediate/int_ntpc_community_2025_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_ntpc_community_2025_endline_survey'), 
@@ -30,24 +30,24 @@ with transformed as (
 {% set rel = ref('stg_ntpc_community_2025_endline_survey') %}
 
 {% set colname_per = get_column_by_substring_postgres(rel, 'first_menstrual_period') %}
-{% set colname_age = get_column_by_substring_postgres(rel, 'woman_age') %}
+{% set colname_age = get_column_by_substring_postgres(rel, 'Age_of_the_respondent') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, 'mixed_material') %}
-{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_How_do_yo') %}
+{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_ispose_the_materials') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_symp = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
 {% set colname_menst_spend = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Ask_the_respondent_Can_you_u') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Ask_the_respondent_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, 'Ask_the_respondent_During_yo') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_firstperiod = get_column_by_substring_postgres(rel, 'Ask_the_respondent_Before_yo') %}
+{% set colname_firstperiod = get_column_by_substring_postgres(rel, 'Ask_the_respondent_w_about_menstruation') %}
 {% set colname_menst_anxiety = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_relig') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
-{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_educa') %}
-{% set colname_ration = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_ratio') %}
+{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_responde_t_s_education_status') %}
+{% set colname_ration = get_column_by_substring_postgres(rel, 'What_is_the_responde_s_ration_card_status') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_marit') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, 'Ask_the_respondent_What_reme') %}
 {% set colname_state = get_column_by_substring_postgres(rel, 'state') %}

--- a/models/intermediate/int_observation_checklist.sql
+++ b/models/intermediate/int_observation_checklist.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_observation_checklist'), 

--- a/models/intermediate/int_rajkot_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_rajkot_community_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_rajkot_community_2025_baseline_survey'), 
@@ -33,21 +33,21 @@ with transformed as (
 {% set colname_per = get_column_by_substring_postgres(rel, 'woman_ageperiod') %}
 {% set colname_age = get_column_by_substring_postgres(rel, 'woman_age') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, 'What_is_the_main_absorbent_mat') %}
-{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_How_do_yo') %}
+{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_ispose_the_materials') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, 'woman_pms') %}
-{% set colname_menst_symp = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
-{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_money_do_') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_predict_when_m') %}
+{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_g_a_sanitary_product') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_smrtphn_access = get_column_by_substring_postgres(rel, 'Ask_the_woman_Do_you_have_ac') %}
+{% set colname_smrtphn_access = get_column_by_substring_postgres(rel, 'Ask_the_woman_Do_y_access_to_smartphone') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
-{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'How_often_do_you_feel_anxious_') %}
+{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'how_often_do_you_fee_t_on_your_daily_life') %}
 {% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_woman_s_religion') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}
-{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_educa') %}
+{% set colname_edu = get_column_by_substring_postgres(rel, 'What_is_the_responde_t_s_education_status') %}
 {% set colname_ration = get_column_by_substring_postgres(rel, 'woman_ration') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, 'Woman_s_marital_status') %}
 {% set colname_menst_rem = get_column_by_substring_postgres(rel, '-') %}

--- a/models/intermediate/int_tfi_school_2024_baseline_survey.sql
+++ b/models/intermediate/int_tfi_school_2024_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_tfi_school_2024_baseline_survey'), 
@@ -30,7 +30,7 @@ with transformed as (
 {% set rel = ref('stg_tfi_school_2024_baseline_survey') %}
 
 {% set colname_per = get_column_by_substring_postgres(rel, 'firstperiodage') %}
-{% set colname_age = get_column_by_substring_postgres(rel, 'woman_age') %}
+{% set colname_age = get_column_by_substring_postgres(rel, 'age') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, 'periodmat') %}
 {% set colname_menst_disp = get_column_by_substring_postgres(rel, 'How_do_you_dispose_the_materia') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, '-') %}
@@ -49,7 +49,7 @@ with transformed as (
 {% set colname_edu = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_ration = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_marit_status = get_column_by_substring_postgres(rel, '-') %}
-{% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_take_duri') %}
+{% set colname_menst_rem = get_column_by_substring_postgres(rel, 'What_remedies_do_you_ods_to_ease_the_pain') %}
 {% set colname_state = get_column_by_substring_postgres(rel, 'state') %}
 {% set colname_district = get_column_by_substring_postgres(rel, 'district') %}
 {% set colname_block = get_column_by_substring_postgres(rel, 'block') %}

--- a/models/intermediate/int_tfi_school_2024_endline_survey.sql
+++ b/models/intermediate/int_tfi_school_2024_endline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_tfi_school_2024_endline_survey'), 
@@ -30,7 +30,7 @@ with transformed as (
 {% set rel = ref('stg_tfi_school_2024_endline_survey') %}
 
 {% set colname_per = get_column_by_substring_postgres(rel, 'firstperiodage') %}
-{% set colname_age = get_column_by_substring_postgres(rel, 'woman_age') %}
+{% set colname_age = get_column_by_substring_postgres(rel, 'age') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, 'Ask_the_respondent_What_is_t') %}
 {% set colname_menst_disp = get_column_by_substring_postgres(rel, 'How_do_you_dispose_the_materia') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, '-') %}

--- a/models/intermediate/int_yflo_community_2025_baseline_survey.sql
+++ b/models/intermediate/int_yflo_community_2025_baseline_survey.sql
@@ -10,7 +10,7 @@
 
 with transformed as (
     select
-        -- All fields except Airbyte and data quality columns
+    -- All fields except Airbyte and data quality columns
         {{ 
             dbt_utils.star(
                 from=ref('stg_yflo_community_2025_baseline_survey'), 
@@ -32,17 +32,17 @@ with transformed as (
 {% set colname_per = get_column_by_substring_postgres(rel, 'woman_ageperiod') %}
 {% set colname_age = get_column_by_substring_postgres(rel, 'woman_age') %}
 {% set colname_menst_mat = get_column_by_substring_postgres(rel, 'What_is_the_main_absorbent_mat') %}
-{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_How_do_yo') %}
+{% set colname_menst_disp = get_column_by_substring_postgres(rel, 'Ask_the_respondent_ispose_the_materials') %}
 {% set colname_pms = get_column_by_substring_postgres(rel, 'woman_pms') %}
-{% set colname_menst_symp = get_column_by_substring_postgres(rel, '-') %}
+{% set colname_menst_symp = get_column_by_substring_postgres(rel, 'What_symptoms_do_you_experienc') %}
 {% set colname_periodtrad = get_column_by_substring_postgres(rel, 'What_are_some_of_the_tradition') %}
-{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_money_do_') %}
-{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_predict_when_m') %}
+{% set colname_menst_spend = get_column_by_substring_postgres(rel, 'On_average_how_much_g_a_sanitary_product') %}
+{% set colname_menst_pred = get_column_by_substring_postgres(rel, 'Can_you_usually_pred_struation_will_start') %}
 {% set colname_menst_info = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_menst_setback = get_column_by_substring_postgres(rel, '-') %}
 {% set colname_smrtphn_access = get_column_by_substring_postgres(rel, 'Do_you_have_access_to_smartpho') %}
 {% set colname_firstperiod = get_column_by_substring_postgres(rel, 'woman_knowm') %}
-{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'How_often_do_you_feel_anxious_') %}
+{% set colname_menst_anxiety = get_column_by_substring_postgres(rel, 'how_often_do_you_fee_t_on_your_daily_life') %}
 {% set colname_religion = get_column_by_substring_postgres(rel, 'What_is_the_woman_s_religion') %}
 {% set colname_caste = get_column_by_substring_postgres(rel, 'woman_caste') %}
 {% set colname_occupation = get_column_by_substring_postgres(rel, 'What_is_the_respondent_s_emplo') %}

--- a/models/staging/stg_barula_community_2025_baseline_survey.sql
+++ b/models/staging/stg_barula_community_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_barula_community_2025_baseline_survey as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_barula_community_2025_baseline_survey as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'barula_community_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_baseline_questionnaire_bareilly.sql
+++ b/models/staging/stg_baseline_questionnaire_bareilly.sql
@@ -15,15 +15,15 @@ with stg_baseline_questionnaire_bareilly_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_baseline_questionnaire_bareilly_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'baseline_questionnaire_bareilly'), "data") }},

--- a/models/staging/stg_bir_community_baseline2025.sql
+++ b/models/staging/stg_bir_community_baseline2025.sql
@@ -15,15 +15,15 @@ with stg_bir_community_baseline2025_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_bir_community_baseline2025_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'bir_community_baseline2025'), "data") }},

--- a/models/staging/stg_caf_ajmer_2024_baselineendline_survey.sql
+++ b/models/staging/stg_caf_ajmer_2024_baselineendline_survey.sql
@@ -15,15 +15,15 @@ with stg_caf_ajmer_2024_baselineendline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_caf_ajmer_2024_baselineendline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'caf_ajmer_2024_baselineendline_survey'), "data") }},

--- a/models/staging/stg_caf_ajmer_students_2025_baseline_survey.sql
+++ b/models/staging/stg_caf_ajmer_students_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_caf_ajmer_students_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_caf_ajmer_students_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'caf_ajmer_students_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_caf_delhi_school_2024_baseline_survey.sql
+++ b/models/staging/stg_caf_delhi_school_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_caf_delhi_school_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_caf_delhi_school_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'caf_delhi_school_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_caf_delhi_school_2025_endline_survey.sql
+++ b/models/staging/stg_caf_delhi_school_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_caf_delhi_school_2025_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_caf_delhi_school_2025_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'caf_delhi_school_2025_endline_survey'), "data") }},

--- a/models/staging/stg_elephanta_community_2025_baseline_survey.sql
+++ b/models/staging/stg_elephanta_community_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_elephanta_community_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_elephanta_community_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'elephanta_community_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_elephanta_community_2025_endline_survey.sql
+++ b/models/staging/stg_elephanta_community_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_elephanta_community_2025_endline_survey as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_elephanta_community_2025_endline_survey as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'elephanta_community_2025_endline_survey'), "data") }},

--- a/models/staging/stg_fbc_community_2024_baseline_survey.sql
+++ b/models/staging/stg_fbc_community_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_fbc_community_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_fbc_community_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'fbc_community_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_fbc_school_boys_2024_baseline_survey.sql
+++ b/models/staging/stg_fbc_school_boys_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_fbc_school_boys_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_fbc_school_boys_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'fbc_school_boys_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_fbc_school_boys_2024_endline_survey.sql
+++ b/models/staging/stg_fbc_school_boys_2024_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_fbc_school_boys_2024_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_fbc_school_boys_2024_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'fbc_school_boys_2024_endline_survey'), "data") }},

--- a/models/staging/stg_fbc_school_girls_2024_baseline_survey.sql
+++ b/models/staging/stg_fbc_school_girls_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_fbc_school_girls_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_fbc_school_girls_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'fbc_school_girls_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_fbc_school_girls_2024_endline_survey.sql
+++ b/models/staging/stg_fbc_school_girls_2024_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_fbc_school_girls_2024_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_fbc_school_girls_2024_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'fbc_school_girls_2024_endline_survey'), "data") }},

--- a/models/staging/stg_fbc_women_jhatingri_baseline_questionaire.sql
+++ b/models/staging/stg_fbc_women_jhatingri_baseline_questionaire.sql
@@ -15,15 +15,15 @@ with stg_fbc_women_jhatingri_baseline_questionaire_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_fbc_women_jhatingri_baseline_questionaire_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'fbc_women_jhatingri_baseline_questionaire'), "data") }},

--- a/models/staging/stg_ffec_community_2025_baseline_survey.sql
+++ b/models/staging/stg_ffec_community_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_ffec_community_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_ffec_community_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'ffec_community_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_forms_mapping.sql
+++ b/models/staging/stg_forms_mapping.sql
@@ -20,12 +20,13 @@ with source as (
         nullif(btrim(place), '') as place,
         nullif(btrim(if_school_then_school_type), '') as school_type,
         nullif(btrim(if_school_then_enrollment_type), '') as enrollment_type,
-        nullif(btrim(if_community_then_community_type), '') as community_type
+        nullif(btrim(if_community_then_community_type), '') as community_type,
+        nullif(btrim(respondent_type), '') as respondent_type
     from {{ source('forms_mapping_data', 'forms_mapping_sheet') }}
 ),
 
 cleaned as (
-    SELECT  
+    select  
         form_name,
         state_name,
         district_name,
@@ -36,12 +37,14 @@ cleaned as (
         beneficiary_type,
         place,
         case when place = 'School' then school_type else community_type end as place_type,
-        case when place = 'School' then enrollment_type else 'N/A' end as enrollment_type
+        case when place = 'School' then enrollment_type else 'N/A' end as enrollment_type,
+        respondent_type
 
     from source
 )
 
-SELECT *
-FROM cleaned
-WHERE form_name IS NOT NULL
-AND form_name != 'NA'
+select *
+from cleaned
+where
+    form_name is not NULL
+    and form_name != 'NA'

--- a/models/staging/stg_jakson_cc_trainers_2025_survey.sql
+++ b/models/staging/stg_jakson_cc_trainers_2025_survey.sql
@@ -15,15 +15,15 @@ with stg_jakson_cc_trainers_2025_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_jakson_cc_trainers_2025_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'jakson_cc_trainers_2025_survey'), "data") }},

--- a/models/staging/stg_jakson_community_2024_baseline_survey.sql
+++ b/models/staging/stg_jakson_community_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_jakson_community_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_jakson_community_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'jakson_community_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_jakson_community_2025_endline_survey.sql
+++ b/models/staging/stg_jakson_community_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_jakson_community_2025_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_jakson_community_2025_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'jakson_community_2025_endline_survey'), "data") }},

--- a/models/staging/stg_jk_fenner_hyd_2025_baseline_survey.sql
+++ b/models/staging/stg_jk_fenner_hyd_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_jk_fenner_hyd_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_jk_fenner_hyd_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'jk_fenner_hyd_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_jk_fenner_hyd_2025_phase_2_baseline_survey.sql
+++ b/models/staging/stg_jk_fenner_hyd_2025_phase_2_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_jk_fenner_hyd_2025_phase_2_baseline_survey as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_jk_fenner_hyd_2025_phase_2_baseline_survey as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'jk_fenner_hyd_2025_phase_2_baseline_survey'), "data") }},

--- a/models/staging/stg_kokari_2024_baseline_survey.sql
+++ b/models/staging/stg_kokari_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_kokari_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_kokari_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'kokari_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_kokari_community_2025_baseline_survey.sql
+++ b/models/staging/stg_kokari_community_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_kokari_community_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_kokari_community_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'kokari_community_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_kokari_community_2025_endline_survey.sql
+++ b/models/staging/stg_kokari_community_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_kokari_community_2025_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_kokari_community_2025_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'kokari_community_2025_endline_survey'), "data") }},

--- a/models/staging/stg_majuli_needs_assessment.sql
+++ b/models/staging/stg_majuli_needs_assessment.sql
@@ -15,15 +15,15 @@ with stg_majuli_needs_assessment_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_majuli_needs_assessment_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'majuli_needs_assessment'), "data") }},

--- a/models/staging/stg_mamta_2025_endline_survey.sql
+++ b/models/staging/stg_mamta_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_mamta_2025_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mamta_2025_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mamta_2025_endline_survey'), "data") }},

--- a/models/staging/stg_mamta_school_2023_workshop_long_survey.sql
+++ b/models/staging/stg_mamta_school_2023_workshop_long_survey.sql
@@ -15,15 +15,15 @@ with stg_mamta_school_2023_workshop_long_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mamta_school_2023_workshop_long_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mamta_school_2023_workshop_long_survey'), "data") }},

--- a/models/staging/stg_mamta_school_2023_workshop_short_survey_ece.sql
+++ b/models/staging/stg_mamta_school_2023_workshop_short_survey_ece.sql
@@ -15,15 +15,15 @@ with stg_mamta_school_2023_workshop_short_survey_ece_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mamta_school_2023_workshop_short_survey_ece_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mamta_school_2023_workshop_short_survey_ece'), "data") }},

--- a/models/staging/stg_mamta_school_2024_baseline_survey.sql
+++ b/models/staging/stg_mamta_school_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_mamta_school_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mamta_school_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mamta_school_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_mamta_school_2025_endline_survey.sql
+++ b/models/staging/stg_mamta_school_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_mamta_school_2025_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mamta_school_2025_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mamta_school_2025_endline_survey'), "data") }},

--- a/models/staging/stg_mosonie_dc_project_teachers_2025_baseline_survey.sql
+++ b/models/staging/stg_mosonie_dc_project_teachers_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_mosonie_dc_project_teachers_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mosonie_dc_project_teachers_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mosonie_dc_project_teachers_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_mosonie_dc_student_2025_baseline_survey.sql
+++ b/models/staging/stg_mosonie_dc_student_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_mosonie_dc_student_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mosonie_dc_student_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mosonie_dc_student_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_mosonie_irctc_community_2025_baseline_survey.sql
+++ b/models/staging/stg_mosonie_irctc_community_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_mosonie_irctc_community_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_mosonie_irctc_community_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'mosonie_irctc_community_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_msi_cs_2024_baseline_survey.sql
+++ b/models/staging/stg_msi_cs_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_msi_cs_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_msi_cs_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'msi_cs_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_msi_cs_2024_endline_survey.sql
+++ b/models/staging/stg_msi_cs_2024_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_msi_cs_2024_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_msi_cs_2024_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'msi_cs_2024_endline_survey'), "data") }},

--- a/models/staging/stg_msi_cs_2025_baseline_survey.sql
+++ b/models/staging/stg_msi_cs_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_msi_cs_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_msi_cs_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'msi_cs_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_msi_cs_2025_endline_survey.sql
+++ b/models/staging/stg_msi_cs_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_msi_cs_2025_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_msi_cs_2025_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'msi_cs_2025_endline_survey'), "data") }},

--- a/models/staging/stg_msi_trainers_2025_baseline_survey.sql
+++ b/models/staging/stg_msi_trainers_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_msi_trainers_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_msi_trainers_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'msi_trainers_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_ntpc_community_2024_baseline_survey.sql
+++ b/models/staging/stg_ntpc_community_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_ntpc_community_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_ntpc_community_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'ntpc_community_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_ntpc_community_2025_endline_survey.sql
+++ b/models/staging/stg_ntpc_community_2025_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_ntpc_community_2025_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_ntpc_community_2025_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'ntpc_community_2025_endline_survey'), "data") }},

--- a/models/staging/stg_observation_checklist.sql
+++ b/models/staging/stg_observation_checklist.sql
@@ -15,15 +15,15 @@ with stg_observation_checklist_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_observation_checklist_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'observation_checklist'), "data") }},

--- a/models/staging/stg_rajkot_community_2025_baseline_survey.sql
+++ b/models/staging/stg_rajkot_community_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_rajkot_community_2025_baseline_survey as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_rajkot_community_2025_baseline_survey as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'rajkot_community_2025_baseline_survey'), "data") }},

--- a/models/staging/stg_tfi_school_2024_baseline_survey.sql
+++ b/models/staging/stg_tfi_school_2024_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_tfi_school_2024_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_tfi_school_2024_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'tfi_school_2024_baseline_survey'), "data") }},

--- a/models/staging/stg_tfi_school_2024_endline_survey.sql
+++ b/models/staging/stg_tfi_school_2024_endline_survey.sql
@@ -15,15 +15,15 @@ with stg_tfi_school_2024_endline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_tfi_school_2024_endline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'tfi_school_2024_endline_survey'), "data") }},

--- a/models/staging/stg_yflo_community_2025_baseline_survey.sql
+++ b/models/staging/stg_yflo_community_2025_baseline_survey.sql
@@ -15,15 +15,15 @@ with stg_yflo_community_2025_baseline_survey_data as (
         
         -- Basic timestamps
         case 
-            when _submission_time is not null then 
-                CAST(_submission_time as timestamp)
-            else null 
+            when _submission_time is not null
+                then 
+                    _submission_time::timestamp 
         end as submission_timestamp,
         
         case 
-            when "end" is not null then 
-                CAST("end" as timestamp)
-            else null 
+            when "end" is not null
+                then 
+                    "end"::timestamp 
         end as end_timestamp,
         
         -- Raw fields (for reference)
@@ -32,9 +32,9 @@ with stg_yflo_community_2025_baseline_survey_data as (
         _airbyte_meta,
         
         -- Data quality indicators
-        case when data is not null then true else false end as has_json_data,
-        case when _submission_time is not null then true else false end as has_submission_time,
-        case when "end" is not null then true else false end as has_end_time,
+        coalesce(data is not null, false) as has_json_data,
+        coalesce(_submission_time is not null, false) as has_submission_time,
+        coalesce("end" is not null, false) as has_end_time,
         
         -- Dynamic JSONB flattening using the macro
         {{ flatten_json_columns(source('survey_raw_data', 'yflo_community_2025_baseline_survey'), "data") }},


### PR DESCRIPTION
## Summary

To resolve non-standard code formatting across repos, we have used sqlfluff library to scan and fix all linting issues in our code. All staging & intermediate models have been updated here with linting fix. Additionally, the client supplied updated list of form varibable names, corresponding to columns we need to extract for metrics from the form data. The targetted models have been updated to reflect the new variables with.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [y] Ran `dbt test` before pushing this PR?
- [y] If you've fixed a bug or added code, the code has been tested and has test cases.
- [ ] Is CI/CD passing?

## Notes


**Linting fix**: for all stg & int models, sqlfluff was used to scan and fix non-standard linting in code. this is a step towards maintaining all code formatting as per industry standard. this would also resolve linting errors during ci/cd

**form variable names updates:** variables names used to extract relevant columns from form, provided by client, was updated to reflect correct naming. updates applied in below int models in lines 32-57:
>int_ffec_community_2025_baseline_survey
>int_jk_fenner_hyd_2025_baseline_survey
>int_jk_fenner_hyd_2025_phase_2_baseline_survey
>int_kokari_community_2025_baseline_survey
>int_mosonie_dc_project_teachers_2025_baseline_survey
>int_mosonie_dc_student_2025_baseline_survey
>int_mosonie_irctc_community_2025_baseline_survey
>int_msi_cs_2025_baseline_survey
>int_msi_cs_2025_endline_survey
>int_ntpc_community_2024_baseline_survey
>int_ntpc_community_2025_endline_survey
>int_rajkot_community_2025_baseline_survey
>int_tfi_school_2024_baseline_survey
>int_tfi_school_2024_endline_survey
>int_yflo_community_2025_baseline_survey

